### PR TITLE
feat: プロンプト入力欄をAIアシスタント出力の上に移動

### DIFF
--- a/web/timtam-web/src/App.tsx
+++ b/web/timtam-web/src/App.tsx
@@ -784,6 +784,45 @@ export function App() {
       </section>
 
       <section style={{ display: 'grid', gap: 8 }}>
+        <h3>オーケストレーター設定</h3>
+        <div style={{ border: '1px solid #ddd', borderRadius: 6, padding: 12, background: '#fff9f0' }}>
+          <div style={{ marginBottom: 8, color: '#666', fontSize: 14 }}>
+            介入判断プロンプト（会議の直近発話に対してAIが判断する際の指示）:
+          </div>
+          <textarea
+            value={promptEditing}
+            onChange={(e) => setPromptEditing(e.target.value)}
+            rows={4}
+            style={{
+              width: '100%',
+              fontFamily: 'monospace',
+              fontSize: 14,
+              padding: 8,
+              borderRadius: 4,
+              border: '1px solid #ccc',
+              resize: 'vertical'
+            }}
+            disabled={promptSaving}
+          />
+          <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>
+            <button onClick={onSavePrompt} disabled={promptSaving || promptEditing === orchestratorPrompt}>
+              {promptSaving ? '保存中...' : '保存'}
+            </button>
+            <button onClick={onResetPrompt} disabled={promptSaving || promptEditing === orchestratorPrompt}>
+              リセット
+            </button>
+            {promptMessage && (
+              <span style={{
+                color: promptMessage.type === 'success' ? '#27ae60' : '#c0392b',
+                fontSize: 14,
+                marginLeft: 4
+              }}>
+                {promptMessage.text}
+              </span>
+            )}
+          </div>
+        </div>
+
         <h3>AIアシスタント</h3>
         <div style={{ position: 'relative' }}>
           <div
@@ -841,45 +880,6 @@ export function App() {
             ))}
             {!partialText && finalSegments.length === 0 && (
               <div style={{ color: '#888' }}>ここに文字起こしが表示される（「文字起こし開始」を押して話してみてね）</div>
-            )}
-          </div>
-        </div>
-
-        <h3>オーケストレーター設定</h3>
-        <div style={{ border: '1px solid #ddd', borderRadius: 6, padding: 12, background: '#fff9f0' }}>
-          <div style={{ marginBottom: 8, color: '#666', fontSize: 14 }}>
-            介入判断プロンプト（会議の直近発話に対してAIが判断する際の指示）:
-          </div>
-          <textarea
-            value={promptEditing}
-            onChange={(e) => setPromptEditing(e.target.value)}
-            rows={4}
-            style={{
-              width: '100%',
-              fontFamily: 'monospace',
-              fontSize: 14,
-              padding: 8,
-              borderRadius: 4,
-              border: '1px solid #ccc',
-              resize: 'vertical'
-            }}
-            disabled={promptSaving}
-          />
-          <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>
-            <button onClick={onSavePrompt} disabled={promptSaving || promptEditing === orchestratorPrompt}>
-              {promptSaving ? '保存中...' : '保存'}
-            </button>
-            <button onClick={onResetPrompt} disabled={promptSaving || promptEditing === orchestratorPrompt}>
-              リセット
-            </button>
-            {promptMessage && (
-              <span style={{
-                color: promptMessage.type === 'success' ? '#27ae60' : '#c0392b',
-                fontSize: 14,
-                marginLeft: 4
-              }}>
-                {promptMessage.text}
-              </span>
             )}
           </div>
         </div>


### PR DESCRIPTION
## 概要

オーケストレーター設定セクション（プロンプト入力欄）をAIアシスタント出力欄の上に移動した。

Closes #14

## 変更内容

- `web/timtam-web/src/App.tsx`のUIセクションの順序を変更
- オーケストレーター設定を最上部に配置

----

Generated with [Claude Code](https://claude.ai/code)