### PR TITLE
feat: LLMに渡す時刻をJSTに統一

### DIFF
--- a/services/orchestrator/worker.ts
+++ b/services/orchestrator/worker.ts
@@ -51,7 +51,7 @@ class WindowBuffer {
   }
   content(): string {
     return this.lines.map(l => {
-      const time = new Date(l.timestamp).toLocaleTimeString('ja-JP');
+      const time = new Date(l.timestamp).toLocaleTimeString('ja-JP', { timeZone: 'Asia/Tokyo' });
       return `[${time}] ${l.text}`;
     }).join('\n');
   }


### PR DESCRIPTION
Web UIと同じタイムゾーン(JST)でLLMプロンプトの時刻を表示するように、toLocaleTimeString()にtimeZoneオプションを明示的に指定した。

Fixes #27

Generated with [Claude Code](https://claude.ai/code)