### PR TITLE
fix: 入力エリアのテキスト色を黒に変更

### DIFF
--- a/web/timtam-web/src/App.tsx
+++ b/web/timtam-web/src/App.tsx
@@ -598,7 +598,7 @@ export function App() {
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder="ひらがなで入力（未入力ならランダム動物名）"
             maxLength={50}
-            style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc', minWidth: 220 }}
+            style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc', minWidth: 220, color: '#000' }}
             data-testid="display-name-input"
           />
           <button onClick={onSaveDisplayName} data-testid="save-name-button">保存</button>
@@ -642,7 +642,7 @@ export function App() {
                   placeholder="meetingId"
                   value={joinMeetingId}
                   onChange={(e) => setJoinMeetingId(e.target.value)}
-                  style={{ minWidth: 260 }}
+                  style={{ minWidth: 260, color: '#000' }}
                   data-testid="join-meeting-id-input"
                 />
                 <button onClick={onJoinExisting} disabled={!apiBaseUrl} data-testid="join-existing-button">このIDで入室</button>

--- a/web/timtam-web/src/GraspConfigPanel.tsx
+++ b/web/timtam-web/src/GraspConfigPanel.tsx
@@ -155,7 +155,8 @@ export function GraspConfigPanel() {
                   borderRadius: 4,
                   border: '1px solid #ccc',
                   resize: 'vertical',
-                  background: '#fff'
+                  background: '#fff',
+                  color: '#000'
                 }}
                 disabled={yamlSaving}
                 placeholder="YAML 設定を入力してください"


### PR DESCRIPTION
### 概要

会議開始時のテキストボックスで、入力した文字がグレーで見づらかった問題を修正しました。

### 変更内容

- `App.tsx`: ユーザー名入力欄とMeeting ID入力欄に `color: '#000'` を追加
- `GraspConfigPanel.tsx`: YAML設定入力欄に `color: '#000'` を追加

プレースホルダはグレーのまま、入力したテキストは黒ではっきり表示されるようになります。

Fixes #76

---
Generated with [Claude Code](https://claude.ai/code)