### PR TITLE
fix: GraspConfigのタイムスタンプをUTC基準で保存・表示

### DIFF
--- a/services/grasp-config/saveConfig.ts
+++ b/services/grasp-config/saveConfig.ts
@@ -109,13 +109,14 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
     // Generate configId with name and timestamp
     // Format: {name}_{timestamp} (e.g., "my-config_20260125_003500")
+    // Use UTC methods to ensure consistent timestamp regardless of server timezone
     const timestamp = new Date(createdAt);
-    const year = timestamp.getFullYear();
-    const month = String(timestamp.getMonth() + 1).padStart(2, '0');
-    const day = String(timestamp.getDate()).padStart(2, '0');
-    const hours = String(timestamp.getHours()).padStart(2, '0');
-    const minutes = String(timestamp.getMinutes()).padStart(2, '0');
-    const seconds = String(timestamp.getSeconds()).padStart(2, '0');
+    const year = timestamp.getUTCFullYear();
+    const month = String(timestamp.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(timestamp.getUTCDate()).padStart(2, '0');
+    const hours = String(timestamp.getUTCHours()).padStart(2, '0');
+    const minutes = String(timestamp.getUTCMinutes()).padStart(2, '0');
+    const seconds = String(timestamp.getUTCSeconds()).padStart(2, '0');
     const timestampStr = `${year}${month}${day}_${hours}${minutes}${seconds}`;
 
     // Sanitize name for use in ID (remove special characters)


### PR DESCRIPTION
## 概要

Grasp設定のタイムスタンプをUTC基準で保存・表示するよう修正しました。

## 変更内容

- バックエンド(saveConfig.ts): configId生成時にUTCメソッドを使用
- フロントエンドは既にtoLocaleString('ja-JP')でローカルタイムゾーン表示済み
- 内部処理は全てUTCタイムスタンプで統一

## 関連Issue

Closes #135

---
Generated with [Claude Code](https://claude.ai/code)