### PR TITLE
fix: 入力、編集できる箇所の文字を黒くする

### DIFF
--- a/web/facilitator/app/globals.css
+++ b/web/facilitator/app/globals.css
@@ -26,10 +26,9 @@ body {
   }
 }
 
-input {
-  color: rgb(17, 24, 39);
-}
-
-textarea {
-  color: rgb(17, 24, 39);
+@layer base {
+  input,
+  textarea {
+    color: rgb(17, 24, 39);
+  }
 }


### PR DESCRIPTION
Braveブラウザに限りINPUTやTEXTAREAの文字が薄く表示される (おそらくダークモードの影響) のを直した。
Chromeではもともと黒く表示されていた。