### PR TITLE
feat: Recall.ai自動退出設定を有効化

### DIFF
--- a/packages/shared/src/recall/RecallAPIClient.ts
+++ b/packages/shared/src/recall/RecallAPIClient.ts
@@ -87,6 +87,34 @@ export interface CreateBotRequest {
       hours: number;
     };
   };
+
+  /** 自動退出設定
+   * @see https://docs.recall.ai/docs/automatic-leaving-behavior
+   */
+  automatic_leave?: {
+    /** 待機室でのタイムアウト（秒）デフォルト: 1200秒 */
+    waiting_room_timeout?: number;
+    /** 誰も参加しない場合のタイムアウト（秒）デフォルト: 1200秒 */
+    noone_joined_timeout?: number;
+    /** 全員退出時の設定 */
+    everyone_left_timeout?: {
+      /** タイムアウト（秒）デフォルト: 2秒 */
+      timeout: number;
+      /** アクティベーション遅延（秒、オプション） */
+      activate_after?: number | null;
+    };
+    /** 沈黙検出設定 */
+    silence_detection?: {
+      /** タイムアウト（秒）デフォルト: 3600秒 */
+      timeout: number;
+      /** アクティベーション遅延（秒）デフォルト: 1200秒 */
+      activate_after: number;
+    };
+    /** 録音なし状態でのタイムアウト（秒）デフォルト: 3600秒 */
+    in_call_not_recording_timeout?: number;
+    /** 録音許可拒否時のタイムアウト（秒）デフォルト: 30秒 */
+    recording_permission_denied_timeout?: number;
+  };
 }
 
 /**

--- a/packages/shared/src/recall/buildCreateBotRequest.test.ts
+++ b/packages/shared/src/recall/buildCreateBotRequest.test.ts
@@ -90,4 +90,26 @@ describe('buildCreateBotRequest', () => {
       },
     });
   });
+
+  it('automatic_leave設定を正しく設定すること', () => {
+    const request = buildCreateBotRequest({
+      meetingUrl: 'https://zoom.us/j/123456789',
+      botName: 'Test Bot',
+      webhookUrl: 'https://example.com/webhook',
+      transcriptionProvider: 'deepgram_streaming',
+      transcriptionLanguage: 'auto',
+    });
+
+    expect(request.automatic_leave).toEqual({
+      waiting_room_timeout: 1200,
+      noone_joined_timeout: 1200,
+      everyone_left_timeout: {
+        timeout: 2,
+      },
+      silence_detection: {
+        timeout: 3600,
+        activate_after: 1200,
+      },
+    });
+  });
 });

--- a/packages/shared/src/recall/buildCreateBotRequest.ts
+++ b/packages/shared/src/recall/buildCreateBotRequest.ts
@@ -53,5 +53,16 @@ export function buildCreateBotRequest(params: BuildCreateBotRequestParams): Crea
         hours: 24,
       },
     },
+    automatic_leave: {
+      waiting_room_timeout: 1200, // デフォルト: 1200秒（20分）
+      noone_joined_timeout: 1200, // デフォルト: 1200秒（20分）
+      everyone_left_timeout: {
+        timeout: 2, // 全員退出後2秒で退出
+      },
+      silence_detection: {
+        timeout: 3600, // 60分沈黙後に退出
+        activate_after: 1200, // 20分後から検知開始
+      },
+    },
   };
 }


### PR DESCRIPTION
Issue #154 の Phase 1 として、Recall.aiの自動退出設定を実装。

## 変更内容
- CreateBotRequestインターフェースにautomatic_leaveフィールドを追加
- buildCreateBotRequest関数に以下の設定を追加:
  - waiting_room_timeout: 1200秒（20分）
  - noone_joined_timeout: 1200秒（20分）
  - everyone_left_timeout: 2秒で退出
  - silence_detection: 60分沈黙後に退出、20分後から検知開始
- テストケースを追加

Closes #154

Generated with [Claude Code](https://claude.ai/code)