### PR TITLE
fix: Graspが0秒目から反応しないよう、Intervalの初期値をDate.now()にする

### DIFF
--- a/services/orchestrator/grasp.test.ts
+++ b/services/orchestrator/grasp.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   Grasp,
   GraspConfig,
+  Interval,
   WindowBuffer,
   Notebook,
   LLMClient,
@@ -513,5 +514,28 @@ describe('Grasp', () => {
       const result = replaceTemplateVariables(template, windowBuffer, notebook);
       expect(result).toBe('プロンプトのみ');
     });
+  });
+});
+
+describe('Interval', () => {
+  it('should not execute immediately after creation (wait one interval first)', () => {
+    const now = Date.now();
+    const interval = new Interval(60000);
+    expect(interval.shouldExecute(now)).toBe(false);
+  });
+
+  it('should execute after cooldown has passed', () => {
+    const start = Date.now();
+    const interval = new Interval(60000);
+    const afterCooldown = start + 60000;
+    expect(interval.shouldExecute(afterCooldown)).toBe(true);
+  });
+
+  it('should not execute again immediately after markExecuted', () => {
+    const start = Date.now();
+    const interval = new Interval(60000);
+    const afterCooldown = start + 60000;
+    interval.markExecuted(afterCooldown);
+    expect(interval.shouldExecute(afterCooldown + 1)).toBe(false);
   });
 });

--- a/services/orchestrator/grasp.ts
+++ b/services/orchestrator/grasp.ts
@@ -52,9 +52,11 @@ export interface Metrics {
 }
 
 export class Interval {
-  private lastExecutionTime: number = 0;
+  private lastExecutionTime: number;
 
-  constructor(private cooldownMs: number) {}
+  constructor(private cooldownMs: number) {
+    this.lastExecutionTime = Date.now();
+  }
 
   shouldExecute(now: number): boolean {
     return now - this.lastExecutionTime >= this.cooldownMs;


### PR DESCRIPTION
Closes #183

IntervalクラスのlastExecutionTimeが0で初期化されていたため、Graspが生成直後から1interval待たずに即座に実行してしまっていた。Date.now()で初期化することで修正した。

Generated with [Claude Code](https://claude.ai/code)